### PR TITLE
Fix#81プロパティ参照不具合の修正 プロパティの存在確認のコードを追加

### DIFF
--- a/components/Event/EventDetail.vue
+++ b/components/Event/EventDetail.vue
@@ -226,7 +226,9 @@
                 ></v-img>
               </nuxt-link>
             </div>
-            <div class="bio-text">{{ user.user_profile.bio }}</div>
+            <template v-if="user && user.user_profile">
+              <div class="bio-text">{{ user.user_profile.bio }}</div>
+            </template>
           </div>
         </template>
         <template v-else> ユーザー情報を読み込んでいます... </template>


### PR DESCRIPTION
user と user.user_profile の存在を確認してから bioを表示するように修正
<template v-if="user && user.user_profile">
  <div class="bio-text">{{ user.user_profile.bio }}</div>
</template>